### PR TITLE
売り切れ商品の購入防止機能を実装（UI無効化＋サーバー側チェック）

### DIFF
--- a/src/main/java/com/example/demo/entity/Item.java
+++ b/src/main/java/com/example/demo/entity/Item.java
@@ -43,11 +43,9 @@ public class Item {
 
 	// DBに保存しない一時的な変数
 	@Transient
-	// 画面表示用
 	private boolean bookmarked;
 
 	public Item() {
-
 	}
 
 	public Item(Long id, Account account, Category category, String name, String image, String memo, Integer price,
@@ -95,8 +93,12 @@ public class Item {
 	public Boolean getSoldOut() {
 		return soldOut;
 	}
-	
-	//	boolean のgetterは → is〇〇() がルール（Javaの決まり）
+
+	// boolean の getter（テンプレートエンジンなどで使用される形式）
+	public boolean isSoldOut() {
+		return Boolean.TRUE.equals(this.soldOut);
+	}
+
 	public boolean isBookmarked() {
 		return bookmarked;
 	}
@@ -133,9 +135,8 @@ public class Item {
 	public void setSoldOut(Boolean soldOut) {
 		this.soldOut = soldOut;
 	}
-	
-	public void setBookmarked(boolean bookmarked) {
-	    this.bookmarked = bookmarked;
-	}
 
+	public void setBookmarked(boolean bookmarked) {
+		this.bookmarked = bookmarked;
+	}
 }

--- a/src/main/resources/templates/item/item_detail.html
+++ b/src/main/resources/templates/item/item_detail.html
@@ -1,38 +1,44 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
 
-<head>
-	<meta charset="UTF-8">
-	<title>Insert title here</title>
-</head>
+	<head>
+		<meta charset="UTF-8">
+		<title>Insert title here</title>
+	</head>
 
-<body>
-	<div th:replace="fragments/header_user :: header"></div>
+	<body>
+		<div th:replace="fragments/header_user :: header"></div>
 
-	<main>
-		<div>
+		<main>
+			<div>
 
-			<p><img th:src="@{'/images/items/' + ${item.image}}" alt="商品画像"></p>
-			<p>価格:<span th:text="${item.price}"></span></p>
-		</div>
+				<p><img th:src="@{'/images/items/' + ${item.image}}" alt="商品画像"></p>
+				<p>価格:<span th:text="${item.price}"></span></p>
+			</div>
 
-		<div>
-			<p>出品者:<span th:text="${item.account.name}"></span> 
-			<a th:href="@{/mypage/user/{id}/detail(id=${item.account.id})}">出品者プロフィールを見る</a>
-			</p>
-			<p>商品名:<span th:text="${item.name}"></span></p>
-			<p>商品詳細:<br><span th:text="${item.memo}"></span></p>
+			<div>
+				<p>出品者:<span th:text="${item.account.name}"></span>
+					<a th:href="@{/mypage/user/{id}/detail(id=${item.account.id})}">出品者プロフィールを見る</a>
+				</p>
+				<p>商品名:<span th:text="${item.name}"></span></p>
+				<p>商品詳細:<br><span th:text="${item.memo}"></span></p>
 
-		</div>
+			</div>
 
-		<a th:href="@{/order/{itemId}(itemId=${item.id})}">購入する</a>
-		<form th:action="@{/chat}" method="post">
-			<input type="hidden" name="itemId" th:value="${item.id}">
-			<input type="hidden" name="ownerId" th:value="${item.account.id}">
-			<button>チャットを始める</button>
-		</form>
-		 <a href="/">一覧へ</a>
-	</main>
-</body>
+			<form th:action="@{/order/{itemId}(itemId=${item.id})}" method="get">
+				<button th:disabled="${item.soldOut}" th:title="${item.soldOut ? '売り切れのため購入できません' : ''}"
+					style="padding: 8px 16px; font-size: 16px;"
+					th:styleappend="${item.soldOut} ? ';background-color: #ccc; color: #666; cursor: not-allowed;' : ''">
+					<span th:text="${item.soldOut ? '売り切れ' : '購入する'}"></span>
+				</button>
+			</form>
+			<form th:action="@{/chat}" method="post">
+				<input type="hidden" name="itemId" th:value="${item.id}">
+				<input type="hidden" name="ownerId" th:value="${item.account.id}">
+				<button>チャットを始める</button>
+			</form>
+			<a href="/">一覧へ</a>
+		</main>
+	</body>
 
 </html>


### PR DESCRIPTION
- 売り切れ商品の「購入する」ボタンをグレーアウト＆無効化（＋購入するリンクをボタンに変更）
- OrderController で売り切れ商品の購入画面表示・購入完了処理をブロック
- Itemエンティティに isSoldOut() を追加