### PR TITLE
fix: review_form.htmlでnickName→nicknameに修正（プロパティ名の誤り対応）

### DIFF
--- a/src/main/resources/templates/review/review_form.html
+++ b/src/main/resources/templates/review/review_form.html
@@ -14,7 +14,7 @@
 		<!-- 対象ユーザーの情報表示 -->
 		<div>
 			<p>レビュー対象: <strong th:text="${reviewee.name}">ユーザー名</strong>（ニックネーム: <span
-					th:text="${reviewee.nickName}">ニックネーム</span>）</p>
+					th:text="${reviewee.nickname}">ニックネーム</span>）</p>
 			<p>プロフィール: <span th:text="${reviewee.profile}">プロフィール文</span></p>
 		</div>
 


### PR DESCRIPTION
レビュー投稿画面（review_form.html）において、ユーザーのニックネーム表示部分でプロパティ名の誤り（nickName → nickname）があったため修正しました。

これにより、nicknameがnullと表示される不具合が解消されます。
