### PR TITLE
style: チャット画面の吹き出し追加とリアルタイムメッセージ部分のレイアウト調整

### DIFF
--- a/src/main/resources/static/js/chat.js
+++ b/src/main/resources/static/js/chat.js
@@ -17,29 +17,23 @@ function setConnected(connected) {
 
 // 接続を行う。
 function connect() {
-  var socket = new SockJS('/chat'); // WebSocket通信開始
+  var socket = new SockJS("/chat"); // WebSocket通信開始
   stompClient = Stomp.over(socket);
   stompClient.connect({}, function (frame) {
     setConnected(true);
-    console.log('Connected: ' + frame);
+    console.log("Connected: " + frame);
     // /receive/messageエンドポイントでメッセージを受信し、表示する
-    stompClient.subscribe('/receive/message', function (response) {
+    stompClient.subscribe("/receive/message", function (response) {
       showMessage(JSON.parse(response.body));
     });
   });
 }
 
 $(document).ready(function () {
-	
-	setTimeout(() => {
-	  connect();
-	}, 3000);
-	
+  setTimeout(() => {
+    connect();
+  }, 3000);
 });
-
-
-
-
 
 // 接続の切断
 function disconnect() {
@@ -52,17 +46,20 @@ function disconnect() {
 
 // メッセージの送信
 function sendMessage() {
-   //send/messageエンドポイントにメッセージを送信する
-  stompClient.send("/send/message", {}, JSON.stringify(
-   {'name': $("#name").val(), 
-	'statement': $("#statement").val(),
-	'itemId':$("#itemId").val(),
-	'chatId':$("#chatId").val(),
-	'myAccountId':$("#myAccountId").val(),
+  //send/messageエンドポイントにメッセージを送信する
+  stompClient.send(
+    "/send/message",
+    {},
+    JSON.stringify({
+      name: $("#name").val(),
+      statement: $("#statement").val(),
+      itemId: $("#itemId").val(),
+      chatId: $("#chatId").val(),
+      myAccountId: $("#myAccountId").val(),
+    })
+  );
+  $("#statement").val("");
 
-	}));
-  $("#statement").val('');
-  
   //stompClient.send("/send/message", {
   //  "content-type": "application/json"
   //}, JSON.stringify({
@@ -81,34 +78,75 @@ function sendMessage() {
 //      "<tr><td>" + message.name + ": " + message.statement + "</td></tr>");
 //}
 
+// function showMessage(message) {
+//   console.log("受信:", message);
+//   $("#message").append(
+//     "<tr><td>" + $('<div/>').text(message.name).html() + ": " + $('<div/>').text(message.statement).html() + "</td></tr>");
+// }
 
 function showMessage(message) {
-  console.log("受信:", message);
-  $("#message").append(
-    "<tr><td>" + $('<div/>').text(message.name).html() + ": " + $('<div/>').text(message.statement).html() + "</td></tr>");
+  const myId = $("#myAccountId").val();
+  const isMine = String(message.myAccountId) === String(myId);
+
+  const bgColor = isMine ? "bg-[#BAEFFF]" : "bg-[#ECFEFE]";
+  const justify = isMine ? "justify-end" : "justify-start";
+
+  const triangle = isMine
+    ? `
+      <span class="absolute bottom-2 -right-2
+                   w-0 h-0
+                   border-l-[10px] border-l-[#ccc]
+                   border-t-[8px] border-t-transparent
+                   border-b-[8px] border-b-transparent"></span>
+      <span class="absolute bottom-2 -right-[7px]
+                   w-0 h-0
+                   border-l-[10px] border-l-[#BAEFFF]
+                   border-t-[8px] border-t-transparent
+                   border-b-[8px] border-b-transparent"></span>
+    `
+    : `
+      <span class="absolute bottom-2 -left-2
+                   w-0 h-0
+                   border-r-[10px] border-r-[#ccc]
+                   border-t-[8px] border-t-transparent
+                   border-b-[8px] border-b-transparent"></span>
+      <span class="absolute bottom-2 -left-[7px]
+                   w-0 h-0
+                   border-r-[10px] border-r-[#ECFEFE]
+                   border-t-[8px] border-t-transparent
+                   border-b-[8px] border-b-transparent"></span>
+    `;
+
+  $("#message").append(`
+    <div class="flex ${justify} mb-2">
+      <div class="relative inline-block min-w-[300px] max-w-[80%] p-3 rounded-xl border border-[#ccc] shadow-sm ${bgColor}">
+        <div class="text-sm text-gray-600 mb-1">${$("<div/>")
+          .text(message.name)
+          .html()}</div>
+        <div class="whitespace-pre-wrap">${$("<div/>")
+          .text(message.statement)
+          .html()}</div>
+        ${triangle}
+      </div>
+    </div>
+  `);
+
+  const messageArea = document.getElementById("message");
+  messageArea.scrollTop = messageArea.scrollHeight;
 }
 
-
-
 // windows.onloadの処理
-$(function () {  
-	
-	$(".form-inline").on('submit', function (e) {
-	  e.preventDefault();
-	  sendMessage();
-	});
+$(function () {
+  $(".form-inline").on("submit", function (e) {
+    e.preventDefault();
+    sendMessage();
+  });
 
-	$("#disconnect").click(function () {
-	  disconnect();
-	});
-	
-//	$("#send").click(function () {
-//	  sendMessage();
-//	});
+  $("#disconnect").click(function () {
+    disconnect();
+  });
 
+  //	$("#send").click(function () {
+  //	  sendMessage();
+  //	});
 });
-
-
-
-
-

--- a/src/main/resources/templates/chats/chatMessage.html
+++ b/src/main/resources/templates/chats/chatMessage.html
@@ -63,10 +63,34 @@
 				<div th:each="messageLog : ${messageLogs}" class="flex mb-2"
 					th:classappend="${messageLog.sender.id == @myAccount.id} ? 'justify-end' : 'justify-start'">
 
-					<div class="inline-block min-w-64 max-w-[80%] p-3 rounded-xl border border-[#ccc] shadow-sm"
+					<div class="relative inline-block min-w-64 max-w-[80%] p-3 rounded-xl border border-[#ccc] shadow-sm"
 						th:classappend="${messageLog.sender.id == @myAccount.id} ? 'bg-[#BAEFFF]' : 'bg-[#ECFEFE]'">
 						<div class="text-sm text-gray-600 mb-1" th:text="${messageLog.sender.nickname}"></div>
 						<div class="whitespace-pre-wrap" th:text="${messageLog.message}"></div>
+
+						<!-- 右下の吹き出し（自分のメッセージ） -->
+						<span th:if="${messageLog.sender.id == @myAccount.id}" class="absolute bottom-2 -right-2
+                 w-0 h-0
+                 border-l-[9px] border-l-[#ccc]
+                 border-t-[8px] border-t-transparent
+                 border-b-[8px] border-b-transparent"></span>
+						<span th:if="${messageLog.sender.id == @myAccount.id}" class="absolute bottom-2 -right-[7px]
+                 w-0 h-0
+                 border-l-[9px] border-l-[#BAEFFF]
+                 border-t-[8px] border-t-transparent
+                 border-b-[8px] border-b-transparent"></span>
+
+						<!-- 左下の吹き出し（相手のメッセージ） -->
+						<span th:if="${messageLog.sender.id != @myAccount.id}" class="absolute bottom-2 -left-2
+                 w-0 h-0
+                 border-r-[9px] border-r-[#ccc]
+                 border-t-[8px] border-t-transparent
+                 border-b-[8px] border-b-transparent"></span>
+						<span th:if="${messageLog.sender.id != @myAccount.id}" class="absolute bottom-2 -left-[7px]
+                 w-0 h-0
+                 border-r-[9px] border-r-[#ECFEFE]
+                 border-t-[8px] border-t-transparent
+                 border-b-[8px] border-b-transparent"></span>
 					</div>
 
 				</div>


### PR DESCRIPTION
@ee1aa @yoshinori-anbiru 
前回、ControllerとDTOを編集しないとできないと考えていた、リアルタイムメッセージ部分のレイアウトは、
DTO内にあるmyAccountIdとログインユーザーのIDで判別することにしたので、JS側だけの編集で問題ありませんでした！

また、よりチャットメッセージに見えるように吹き出しのレイアウトを調整しましたので、こちらも合わせて確認お願いします！

<img width="3056" height="3388" alt="localhost_8080_chat_chatId=1 (1)" src="https://github.com/user-attachments/assets/11fa5fa9-f2ce-4034-a533-1cd7aa5cd906" />

<img width="2928" height="2944" alt="localhost_8080_chat_chatId=1" src="https://github.com/user-attachments/assets/f81ac4c3-a26a-45cf-bf51-31ece0df46b3" />